### PR TITLE
fix for DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "bin": {
     "po2json": "bin/po2json-js"
   },
-  "main": "./lib/po2json-js",
+  "main": "./bin/po2json-js",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
(node:16090) [DEP0128] DeprecationWarning: Invalid 'main' field in '/node_modules/po2json/package.json' of './lib/po2json'. Please either fix that or report it to the module author